### PR TITLE
Feature: Pickup in Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Pickup in Store support
+
 ## [0.0.1] - 2023-05-25
 
 ### Added


### PR DESCRIPTION
Depends on https://github.com/vtex/connector-paypal-commerce-platform/pull/65

Adds similar support for pickup in store to the PayPal smart buttons injected by this app into checkout v6.

Linked here: https://arthur--sandboxusdev.myvtex.com

To test, add a product to cart, then go to the cart page of checkout (not the minicart) and click the PayPal button on the right.