### PR TITLE
Fix: reset selected shipping option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reset selected shipping option when PayPal UI is opened
+- Refetch orderForm in checkout if PayPal UI is closed
+
 ## [0.1.0] - 2023-07-03
 
 ### Added


### PR DESCRIPTION
Because the user may have a default shipping address in PayPal that is not within the radius of a VTEX pickup point, this PR adjusts the initialization logic so that if store pickup is currently selected in the orderForm, it will instead select the first delivery option before sending the data to PayPal. 

Also, if the user closes the PayPal popup and the orderForm has been changed, previously the VTEX UI would not update unless the page was refreshed. Now the UI will update automatically.

New version linked in https://paypaltest--eriksbikeshop.myvtex.com