### PR TITLE
Feature: disable Debit or Credit Card smart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `disableCards` PayPalCP app setting
+
 ## [0.1.1] - 2023-08-11
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -1099,6 +1099,7 @@ const generateBreakdown = (totalizers, currency) => {
       merchantId,
       immediateCapture,
       disablePayPalCredit,
+      disableCards,
     } = window.payPalSettings
 
     const orderForm = await vtexjs.checkout.getOrderForm()
@@ -1106,11 +1107,20 @@ const generateBreakdown = (totalizers, currency) => {
 
     const script = document.createElement('script')
 
+    const disabledPayments = []
+
+    if (disableCards) disabledPayments.push('card')
+    if (disablePayPalCredit) disabledPayments.push('credit')
+
     script.src = `https://www.paypal.com/sdk/js?client-id=${
       production ? productionClientId : sandboxClientId
     }&merchant-id=${merchantId}&currency=${currency}&intent=${
       immediateCapture ? 'capture' : 'authorize'
-    }&commit=true${disablePayPalCredit ? `&disable-funding=credit` : ``}`
+    }&commit=true${
+      disabledPayments.length
+        ? `&disable-funding=${disabledPayments.join(',')}`
+        : ``
+    }`
     script.setAttribute(
       'data-partner-attribution-id',
       production ? productionBNCode : sandboxBNCode


### PR DESCRIPTION
#### What problem is this solving?

Adds logic to respect the new app setting to enable/disable the "Debit or Credit Card" smart button (added [here](https://github.com/vtex/connector-paypal-commerce-platform/pull/72)), for clients who may not wish to offer PayPal Guest Checkout. 

#### How to test it?

Linked here: https://paypaltest--eriksbikeshop.myvtex.com
