### PR TITLE
Prevent unnecessary rerender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent rerender of PayPal buttons if they already exist
+
 ## [0.2.0] - 2023-08-14
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -656,7 +656,10 @@ const generateBreakdown = (totalizers, currency) => {
   }
 
   const renderButtons = async () => {
-    if (typeof paypal === 'undefined') {
+    if (
+      typeof paypal === 'undefined' ||
+      $('#paypal-button-container').children().length
+    ) {
       return
     }
 


### PR DESCRIPTION
If the PayPal buttons have already been rendered, don't render them again. This PR should prevent "flickering" as the buttons are re-rendered, and in some cases, prevent duplicate buttons from being rendered.

New version linked here: https://arthur--sandboxusdev.myvtex.com/checkout